### PR TITLE
Allow different keys names and configure additional envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ helm install -f values.yaml --name=kowl cloudhut/kowl
 | `secret.kafka.tlsKey` | Kafka TLS key | (none) |
 | `secret.kafka.tlsPassphrase` | Kafka TLS passphrase | (none) |
 | `secret.cloudhut.licenseToken` | License token for Kowl business (business) | (none) |
-| `secret.keynames` | Alternative named for secret keys. Keys for kafka-tls-ca, kafka-tls-cert and kafka-tls-key does not need to alter here. | See values.yaml |
+| `secret.keyname.cloudhut-license-token` | Secret key name for the cloudhut license token  | `cloudhut-license-token` |
+| `secret.keyname.kafka-tls-passphrase` | Secret key name for the TLS passphrase  | `kafka-tls-passphrase` |
+| `secret.keyname.kafka-sasl-password` | Secret key name for the SASL password  | `kafka-sasl-password` |
 | `login.google.clientSecret` | Google OAuth client secret (business) | (none) |
 | `login.github.clientSecret` | GitHub OAuth client secret (business) | (none) |
 | `login.github.personalAccessToken` | GitHub personal access token (business) | (none) |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ helm install -f values.yaml --name=kowl cloudhut/kowl
 | `nodeSelector` | Node selector used in deployment | `{}` |
 | `tolerations` | Tolerations for tainted nodes | `[]` |
 | `affinity` | Pod (anti)affinities | `{}` |
+| `extraVolumes` | Add additional volumes, e. g. for tls keys | `""` |
+| `extraVolumeMounts` | Add additional volumes mounts, e. g. for tls keys | `""` |
+| `extraEnv` | Additional environment variables for kowl | `""` |
+| `extraEnvFrom` | Additional environment variables for kowl mapped from Secret or ConfigMap | `""` |
 | `kowl.config` | Kowl config content | `{}` |
 | `kowl.roles` | Kowl roles config content (business) | (none) |
 | `kowl.roleBindings` | Kowl rolebindings config content (business) | (none) |
@@ -56,11 +60,20 @@ helm install -f values.yaml --name=kowl cloudhut/kowl
 | `secret.kafka.tlsKey` | Kafka TLS key | (none) |
 | `secret.kafka.tlsPassphrase` | Kafka TLS passphrase | (none) |
 | `secret.cloudhut.licenseToken` | License token for Kowl business (business) | (none) |
+| `secret.keynames` | Alternative named for secret keys. Keys for kafka-tls-ca, kafka-tls-cert and kafka-tls-key does not need to alter here. | See values.yaml |
 | `login.google.clientSecret` | Google OAuth client secret (business) | (none) |
 | `login.github.clientSecret` | GitHub OAuth client secret (business) | (none) |
 | `login.github.personalAccessToken` | GitHub personal access token (business) | (none) |
 
 Further documentation can be found in the [examples](./examples).
+
+#### Usage of the tpl Function
+The tpl function allows us to pass string values from values.yaml through the templating engine. It is used for the following values:
+
+* extraEnv
+* extraEnvFrom
+* extraVolumes
+* extraVolumeMounts
 
 ### Kowl Config / Mounted secrets
 

--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         - name: secrets
           secret:
             secretName: {{ include "kowl.secretName" . }}
+        {{- with .Values.extraVolumes }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           args:
@@ -58,6 +61,9 @@ spec:
             - name: secrets
               mountPath: /etc/kowl/secrets
               readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ include "kowl.serverListenPort" . }}
@@ -121,7 +127,6 @@ spec:
             {{- with .Values.extraEnvFrom }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -79,19 +79,19 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kowl.secretName" . }}
-                  key: kafka-sasl-password
+                  key: {{ get .Values.secret.keyName "kafka-sasl-password" }}
             - name: KAFKA_TLS_PASSPHRASE
               valueFrom:
                secretKeyRef:
                  name: {{ include "kowl.secretName" . }}
-                 key: kafka-tls-passphrase
+                 key: {{ get .Values.secret.keyName "kafka-tls-passphrase" }}
             {{- if eq .Values.image.repository "quay.io/cloudhut/kowl-business" }}
             {{- if not .Values.kowl.config.cloudhut }}
             - name: CLOUDHUT_LICENSE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kowl.secretName" . }}
-                  key: cloudhut-license-token
+                  key: {{ get .Values.secret.keyName "cloudhut-license-token" }}
             {{- end }}
             - name: LOGIN_JWT_SECRET
               valueFrom:
@@ -113,6 +113,13 @@ spec:
                secretKeyRef:
                  name: {{ include "kowl.secretName" . }}
                  key: login-github-personal-access-token
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
             {{- end }}
 
       {{- with .Values.nodeSelector }}

--- a/kowl/values.yaml
+++ b/kowl/values.yaml
@@ -98,6 +98,11 @@ extraEnv: ""
 # Additional environment variables for kowl mapped from Secret or ConfigMap
 extraEnvFrom: ""
 
+# Add additional volumes, e. g. for tls keys
+extraVolumes: ""
+# Add additional volumes mounts, e. g. for tls keys
+extraVolumeMounts: ""
+
 secret:
   # existingSecret can be used if you create the secret with the needed key value pairs on your own. Specify the
   # secret name here and it will be used. Please make sure you specify all the below key names even if you don't need them.

--- a/kowl/values.yaml
+++ b/kowl/values.yaml
@@ -90,6 +90,14 @@ kowl:
   # roles:
   # roleBindings:
 
+# Additional environment variables for kowl
+extraEnv: ""
+  # - name: KAFKA_RACKID
+  #   value: "1"
+
+# Additional environment variables for kowl mapped from Secret or ConfigMap
+extraEnvFrom: ""
+
 secret:
   # existingSecret can be used if you create the secret with the needed key value pairs on your own. Specify the
   # secret name here and it will be used. Please make sure you specify all the below key names even if you don't need them.
@@ -107,6 +115,14 @@ secret:
   #  - login-github-oauth-client-secret
   #  - login-github-personal-access-token
   existingSecret:
+  # Alternative named for secret keys
+  # Keys for kafka-tls-ca, kafka-tls-cert and kafka-tls-key does not need to alter here. But additional env variables needs to be set like
+  # KAFKA_TLS_CAFILEPATH=/etc/kowl/secrets/<key-name>
+  keyName:
+    cloudhut-license-token: "cloudhut-license-token"
+    kafka-tls-passphrase: "kafka-tls-passphrase"
+    kafka-sasl-password: "kafka-sasl-password"
+
   # Secret values in case you want the chart to create a secret
   # Kafka secrets
   kafka: {}


### PR DESCRIPTION
Fixes #11 

This PR makes the hardcoded secret key name configurable.

On top, there are 2 new values `extraEnv` and `extraEnvFrom`. This mechanism is copied from the keycloak helm chart.

This motivation of the PR is to increase the compatibility between the secrets generated by strimzi kafka operator and kafka kowl. 

Since the strimzi kafka operator hold tls user keys and tls ca in different secrets, I add extraVolumes to allow additional volumeMounts
