### PR TITLE
Allow helm functions in config

### DIFF
--- a/kowl/templates/configmap.yaml
+++ b/kowl/templates/configmap.yaml
@@ -6,16 +6,16 @@ metadata:
     {{- include "kowl.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- toYaml .Values.kowl.config | nindent 4}}
+    {{- tpl (toYaml .Values.kowl.config) $ | nindent 4 }}
 
   {{- if .Values.kowl.roles }}
   roles.yaml: |
     roles:
-      {{- toYaml .Values.kowl.roles | nindent 6 }}
+      {{- tpl (toYaml .Values.kowl.config.roles) $ | nindent 6 }}
   {{- end }}
 
   {{- if .Values.kowl.roleBindings }}
   role-bindings.yaml: |
     roleBindings:
-      {{- toYaml .Values.kowl.roleBindings | nindent 6 }}
+      {{- tpl (toYaml .Values.kowl.config.roleBindings) $ | nindent 6 }}
   {{- end }}


### PR DESCRIPTION
The PR add the functionality to use helm functions for the kowl config.

In combination with [helm lookup](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) this can be used to automatic lookup the kafka broker URLs