### PR TITLE
add option for adding annotations for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ helm install -f values.yaml kowl cloudhut/kowl
 | `podAnnotations` | Annotations to attach on Kowl pod | `{}` |
 | `podSecurityContext` | Pod Security Context | `{runAsUser: 99, fsGroup: 99}` |
 | `securityContext` | Container Security Context | `{runAsNonRoot: true}` |
+| `deployment.annotations` | Deployment annotations | `{}` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `service.type` | Annotations to attach to service | `{}` |

--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "kowl.fullname" . }}
   labels:
     {{- include "kowl.labels" . | nindent 4 }}
+  {{- with (.Values.deployment).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/kowl/values.yaml
+++ b/kowl/values.yaml
@@ -40,6 +40,9 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+deployment:
+  annotations: {}
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This adds support for adding annotations to deployments. The check is backwards-compatible, so any values files without a `deployment` key will still work.