### PR TITLE
add missing podAnnotations into deploy template

### DIFF
--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -15,9 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
+        {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         {{- include "kowl.selectorLabels" . | nindent 8 }}
     spec:

--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         {{- include "kowl.selectorLabels" . | nindent 8 }}
     spec:

--- a/kowl/templates/deployment.yaml
+++ b/kowl/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-        {{ toYaml .Values.podAnnotations | indent 8 }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
         {{- include "kowl.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
I've noticed the deployment template is not rendering the `podAnnotations` field available in the `values.yaml`,
this PR aims to fix that