### PR TITLE
Enable the setting of target port for service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ helm install -f values.yaml kowl cloudhut/kowl
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `80` |
 | `service.type` | Annotations to attach to service | `{}` |
+| `service.targetPort` | Internal service port | `http` |
 | `ingress.enabled` | Whether or not to deploy an ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
 | `ingress.hosts[0].host` | Ingress hostname | `chart-example.local` |

--- a/examples/kowl-extra-containers/values.yaml
+++ b/examples/kowl-extra-containers/values.yaml
@@ -47,6 +47,6 @@ extraContainers:
     args:
       - --provider=azure
       - --email-domain=*
-      - --upstream=http://localhost:80/
+      - --upstream=http://localhost:8080/
       - --http-address=0.0.0.0:4180
       - --azure-tenant=520d7091-fbda-4516-8e71-cca8fc2f3f8e

--- a/kowl/templates/service.yaml
+++ b/kowl/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/kowl/values.yaml
+++ b/kowl/values.yaml
@@ -44,6 +44,7 @@ service:
   type: ClusterIP
   port: 80
   annotations: {}
+  targetPort: http
 
 ingress:
   enabled: false


### PR DESCRIPTION
During testing of the sidecar feature #23 I need to set the target port to enable usage of the oauth2-proxy